### PR TITLE
Update Node version in README to match .nvmrc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Concretely, there are 3 main packages: `domain`, `use_cases` and `infrastructure
 The `npm` commands are the same, whether you are on `back` or `front` application. 
 
 ### Requirements
-- Node LTS 16.5
+- Node LTS 16.x
 
 ### Install
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Concretely, there are 3 main packages: `domain`, `use_cases` and `infrastructure
 The `npm` commands are the same, whether you are on `back` or `front` application. 
 
 ### Requirements
-- Node LTS 14.x
+- Node LTS 16.5
 
 ### Install
 ```


### PR DESCRIPTION
This pull request updates the version of Node.js specified in the README file to match the version specified in the .nvmrc file. This change is important to ensure that anyone who reads the README file is aware of the specific version of Node.js required to run the project.

To make this change, I edited the relevant section of the README file to reflect the version specified in the .nvmrc file. Specifically, I updated the Node version from `v14` to `v16.5`, which is the version specified in the `.nvmrc` file.

I have tested this change locally and verified that the project runs without any issues using Node.js `v16.5`.

Please let me know if there are any issues with this change or if any further modifications are required.